### PR TITLE
Fixed failures on update and create Opportunities

### DIFF
--- a/app/jobs/push_opportunity_to_salesforce_job.rb
+++ b/app/jobs/push_opportunity_to_salesforce_job.rb
@@ -52,11 +52,11 @@ class PushOpportunityToSalesforceJob < ApplicationJob
 
   def calculate_start_date
     year = Date.today.year
-    between = Date.today.between?(Date.strptime(year.to_s + '-04-01', '%Y-%m-%d'), Date.strptime(year.to_s + '-11-01', '%Y-%m-%d'))
-    if between
-      Date.strptime(year.to_s + '-08-15', '%Y-%m-%d')
-    else
-      Date.strptime(year.to_s + '-01-06', '%Y-%m-%d')
-    end
+    between_april_and_november = Date.today.between?(Date.strptime(year.to_s + '-04-01', '%Y-%m-%d'), Date.strptime(year.to_s + '-11-01', '%Y-%m-%d'))
+
+    fall_semester = Date.strptime(year.to_s + '-08-15', '%Y-%m-%d')
+    spring_semester = Date.strptime(year.to_s + '-01-06', '%Y-%m-%d')
+
+    between_april_and_november ? fall_semester : spring_semester
   end
 end

--- a/spec/cassettes/PushOpportunityToSalesforceJob/pushes_a_new_opportunity.yml
+++ b/spec/cassettes/PushOpportunityToSalesforceJob/pushes_a_new_opportunity.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: "<salesforce_instance_url>/services/data/v51.0/sobjects/Opportunity"
     body:
       encoding: UTF-8
-      string: '{"Contact__c":"0034C00000T6UZLQA3","CloseDate":"2021-08-30","StageName":"Confirmed
-        Adoption Won","Type":"New Business","Students__c":"76","Student_No_Status__c":"Reported","Time_Period__c":"Year","Class_Start_Date__c":"2021-08-30","AccountId":"0014C00000ZiK4nQAF","Book__c":"a0Z4C000002JRFOUA4","LeadSource":"Web","Name":"new
+      string: '{"Contact__c":"003U000001t59XgIAI","CloseDate":"2021-09-20","StageName":"Confirmed
+        Adoption Won","Type":"New Business","Students__c":"48","Student_No_Status__c":"Reported","Time_Period__c":"Year","Class_Start_Date__c":"2021-08-15","AccountId":"001U000001k36GVIAY","Book__c":"a0ZU000000DLpEMMA1","LeadSource":"Web","Name":"new
         from openstax-salesforce-api"}'
     headers:
       User-Agent:
@@ -25,12 +25,14 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Mon, 30 Aug 2021 20:14:38 GMT
+      - Mon, 20 Sep 2021 14:49:42 GMT
       Set-Cookie:
-      - BrowserId=50LydgnOEey62ccEbRHfeg; domain=.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:14:38 GMT; Max-Age=31536000
-      - CookieConsentPolicy=0:1; domain=openstax--dev.my.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:14:38 GMT; Max-Age=31536000
+      - BrowserId=_X3dtRohEeyRVIkoqYY9Dg; domain=.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:43 GMT; Max-Age=31536000
+      - CookieConsentPolicy=0:1; domain=openstax--qa.my.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:43 GMT; Max-Age=31536000
+      - LSKey-c$CookieConsentPolicy=0:1; domain=openstax--qa.my.salesforce.com; path=/;
+        expires=Tue, 20-Sep-2022 14:49:43 GMT; Max-Age=31536000
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Robots-Tag:
@@ -38,9 +40,9 @@ http_interactions:
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Sforce-Limit-Info:
-      - api-usage=1385/5000000
+      - api-usage=5909/5000000
       Location:
-      - "/services/data/v51.0/sobjects/Opportunity/0064C00000EoSLhQAN"
+      - "/services/data/v51.0/sobjects/Opportunity/0067h00000BrngnAAB"
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -49,6 +51,6 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"id":"0064C00000EoSLhQAN","success":true,"errors":[]}'
-  recorded_at: Mon, 30 Aug 2021 20:14:41 GMT
+      string: '{"id":"0067h00000BrngnAAB","success":true,"errors":[]}'
+  recorded_at: Mon, 20 Sep 2021 14:43:22 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/PushOpportunityToSalesforceJob/pushes_an_existing_opportunity.yml
+++ b/spec/cassettes/PushOpportunityToSalesforceJob/pushes_an_existing_opportunity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: "<salesforce_instance_url>/services/data/v51.0/query?q=SELECT%20Id,%20TermYear__c,%20Book_Text__c,%20Contact__c,%20New__c,%20CloseDate,%20StageName,%20Type,%20Students__c,%20Student_No_Status__c,%20Time_Period__c,%20Class_Start_Date__c,%20AccountId,%20Book__c,%20LeadSource,%20OS_Accounts_ID__c,%20Name%20FROM%20Opportunity%20WHERE%20(Id%20=%20%270064C00000DtyZIQAZ%27)%20LIMIT%201"
+    uri: "<salesforce_instance_url>/services/data/v51.0/query?q=SELECT%20Id,%20TermYear__c,%20Book_Text__c,%20Contact__c,%20New__c,%20CloseDate,%20StageName,%20Type,%20Students__c,%20Student_No_Status__c,%20Time_Period__c,%20Class_Start_Date__c,%20AccountId,%20Book__c,%20LeadSource,%20OS_Accounts_ID__c,%20Name%20FROM%20Opportunity%20WHERE%20(Id%20=%20%270067h00000Brg8EAAR%27)%20LIMIT%201"
     body:
       encoding: US-ASCII
       string: ''
@@ -21,12 +21,14 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Aug 2021 20:05:01 GMT
+      - Mon, 20 Sep 2021 14:49:38 GMT
       Set-Cookie:
-      - BrowserId=jxud2gnNEeyEoB8uy-uY5A; domain=.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:05:01 GMT; Max-Age=31536000
-      - CookieConsentPolicy=0:1; domain=openstax--dev.my.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:05:01 GMT; Max-Age=31536000
+      - BrowserId=-rs7HBohEey7dKOja7Ufsg; domain=.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:38 GMT; Max-Age=31536000
+      - CookieConsentPolicy=0:1; domain=openstax--qa.my.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:38 GMT; Max-Age=31536000
+      - LSKey-c$CookieConsentPolicy=0:1; domain=openstax--qa.my.salesforce.com; path=/;
+        expires=Tue, 20-Sep-2022 14:49:38 GMT; Max-Age=31536000
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Robots-Tag:
@@ -34,7 +36,7 @@ http_interactions:
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Sforce-Limit-Info:
-      - api-usage=1345/5000000
+      - api-usage=5909/5000000
       Content-Type:
       - application/json;charset=UTF-8
       Vary:
@@ -43,17 +45,17 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Opportunity","url":"/services/data/v51.0/sobjects/Opportunity/0064C00000DtyZIQAZ"},"Id":"0064C00000DtyZIQAZ","TermYear__c":"2021
-        - 22 Fall","Book_Text__c":"Managerial Accounting","Contact__c":"0034C00000Toa9PQAR","New__c":true,"CloseDate":"2021-08-30","StageName":"Confirmed
-        Adoption Won","Type":"Renewal - Verified","Students__c":null,"Student_No_Status__c":"Reported","Time_Period__c":"Year","Class_Start_Date__c":"2021-08-30","AccountId":"0014C00000aB0swQAC","Book__c":"a0Z4C000002JXWSUA4","LeadSource":"Web","OS_Accounts_ID__c":"219912","Name":"Man
-        Acct - 2021 - 22 - Linh Tran"}]}'
-  recorded_at: Mon, 30 Aug 2021 20:05:01 GMT
+      string: '{"totalSize":1,"done":true,"records":[{"attributes":{"type":"Opportunity","url":"/services/data/v51.0/sobjects/Opportunity/0067h00000Brg8EAAR"},"Id":"0067h00000Brg8EAAR","TermYear__c":"2021
+        - 22 Fall","Book_Text__c":"Managerial Accounting","Contact__c":"003U000001t59YjIAI","New__c":true,"CloseDate":"2021-09-20","StageName":"Previous
+        Adoption","Type":"Renewal - Verified","Students__c":null,"Student_No_Status__c":"Reported","Time_Period__c":"Year","Class_Start_Date__c":"2021-09-16","AccountId":"001U000001QYuEjIAL","Book__c":"a0ZU000000BGyUSMA1","LeadSource":"Web","OS_Accounts_ID__c":"74072","Name":"Man
+        Acct - 2021 - 22 - Christopher Gray"}]}'
+  recorded_at: Mon, 20 Sep 2021 14:43:15 GMT
 - request:
     method: patch
-    uri: "<salesforce_instance_url>/services/data/v51.0/sobjects/Opportunity/0064C00000DtyZIQAZ"
+    uri: "<salesforce_instance_url>/services/data/v51.0/sobjects/Opportunity/0067h00000Brg8EAAR"
     body:
       encoding: UTF-8
-      string: '{"CloseDate":"2021-08-30","Students__c":"167","Class_Start_Date__c":"2021-08-30"}'
+      string: '{"CloseDate":"2021-09-20","Students__c":"105"}'
     headers:
       User-Agent:
       - Faraday v1.5.1
@@ -71,12 +73,14 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 30 Aug 2021 20:05:01 GMT
+      - Mon, 20 Sep 2021 14:49:38 GMT
       Set-Cookie:
-      - BrowserId=j1cgGAnNEey62ccEbRHfeg; domain=.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:05:01 GMT; Max-Age=31536000
-      - CookieConsentPolicy=0:1; domain=openstax--dev.my.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:05:01 GMT; Max-Age=31536000
+      - BrowserId=-wKkdRohEey7dKOja7Ufsg; domain=.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:38 GMT; Max-Age=31536000
+      - CookieConsentPolicy=0:1; domain=openstax--qa.my.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:38 GMT; Max-Age=31536000
+      - LSKey-c$CookieConsentPolicy=0:1; domain=openstax--qa.my.salesforce.com; path=/;
+        expires=Tue, 20-Sep-2022 14:49:38 GMT; Max-Age=31536000
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Robots-Tag:
@@ -84,14 +88,14 @@ http_interactions:
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Sforce-Limit-Info:
-      - api-usage=1345/5000000
+      - api-usage=5910/5000000
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Mon, 30 Aug 2021 20:05:03 GMT
+  recorded_at: Mon, 20 Sep 2021 14:43:17 GMT
 - request:
     method: patch
-    uri: "<salesforce_instance_url>/services/data/v51.0/sobjects/Opportunity/0064C00000DtyZIQAZ"
+    uri: "<salesforce_instance_url>/services/data/v51.0/sobjects/Opportunity/0067h00000Brg8EAAR"
     body:
       encoding: UTF-8
       string: "{}"
@@ -112,12 +116,14 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Mon, 30 Aug 2021 20:05:03 GMT
+      - Mon, 20 Sep 2021 14:49:41 GMT
       Set-Cookie:
-      - BrowserId=kIIK9AnNEeyONP9jwL86pA; domain=.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:05:03 GMT; Max-Age=31536000
-      - CookieConsentPolicy=0:1; domain=openstax--dev.my.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:05:03 GMT; Max-Age=31536000
+      - BrowserId=_Esp6BohEeyq2mXKwYh2Og; domain=.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:41 GMT; Max-Age=31536000
+      - CookieConsentPolicy=0:1; domain=openstax--qa.my.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:41 GMT; Max-Age=31536000
+      - LSKey-c$CookieConsentPolicy=0:1; domain=openstax--qa.my.salesforce.com; path=/;
+        expires=Tue, 20-Sep-2022 14:49:41 GMT; Max-Age=31536000
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Robots-Tag:
@@ -125,9 +131,9 @@ http_interactions:
       Cache-Control:
       - no-cache,must-revalidate,max-age=0,no-store,private
       Sforce-Limit-Info:
-      - api-usage=1345/5000000
+      - api-usage=5909/5000000
     body:
       encoding: UTF-8
       string: ''
-  recorded_at: Mon, 30 Aug 2021 20:05:05 GMT
+  recorded_at: Mon, 20 Sep 2021 14:43:18 GMT
 recorded_with: VCR 6.0.0

--- a/spec/cassettes/PushOpportunityToSalesforceJob/sf_setup.yml
+++ b/spec/cassettes/PushOpportunityToSalesforceJob/sf_setup.yml
@@ -21,12 +21,12 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Mon, 30 Aug 2021 20:14:37 GMT
+      - Mon, 20 Sep 2021 14:49:37 GMT
       Set-Cookie:
-      - BrowserId=5o_2jAnOEey2nSvGkWlogA; domain=.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:14:37 GMT; Max-Age=31536000
+      - BrowserId=-eyg7RohEey6qg9Kb3Xd-w; domain=.salesforce.com; path=/; expires=Tue,
+        20-Sep-2022 14:49:37 GMT; Max-Age=31536000
       - CookieConsentPolicy=0:0; domain=test.salesforce.com; path=/; expires=Tue,
-        30-Aug-2022 20:14:37 GMT; Max-Age=31536000
+        20-Sep-2022 14:49:37 GMT; Max-Age=31536000
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
@@ -47,6 +47,6 @@ http_interactions:
       - chunked
     body:
       encoding: ASCII-8BIT
-      string: '{"access_token":"<salesforce_access_token>","instance_url":"<salesforce_instance_url>","id":"<salesforce_id>","token_type":"Bearer","issued_at":"1630354478393","signature":"<salesforce_signature>"}'
-  recorded_at: Mon, 30 Aug 2021 20:14:38 GMT
+      string: '{"access_token":"<salesforce_access_token>","instance_url":"<salesforce_instance_url>","id":"<salesforce_id>","token_type":"Bearer","issued_at":"1632149377494","signature":"<salesforce_signature>"}'
+  recorded_at: Mon, 20 Sep 2021 14:43:14 GMT
 recorded_with: VCR 6.0.0

--- a/spec/factories/api_new_opportunity.rb
+++ b/spec/factories/api_new_opportunity.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :api_new_opportunity, class: Opportunity do
     term_year { [ '2019 - 20 Spring', '2019 - 20 Fall', '2018 - 19 Fall', '2018 - 19 Spring'].sample }
     book_name { 'Prealgebra' }
-    contact_id { '0034C00000T6UZLQA3' }
+    contact_id { '003U000001t59XgIAI' }
     new { [true, false].sample }
     close_date { Date.today }
     stage_name { 'Confirm Adoption Won' }
@@ -13,7 +13,7 @@ FactoryBot.define do
     student_number_status { 'Reported' }
     time_period { 'Year' }
     class_start_date { Date.today }
-    school_id { '0014C00000ZiK4nQAF' }
+    school_id { '001U000001k36GVIAY' }
     book_id { '' }
     lead_source { 'Web' }
     os_accounts_id { 1 }

--- a/spec/factories/api_opportunity.rb
+++ b/spec/factories/api_opportunity.rb
@@ -3,10 +3,10 @@ require 'time'
 
 FactoryBot.define do
   factory :api_opportunity, class: Opportunity do
-    salesforce_id { '0064C00000DtyZIQAZ' }
+    salesforce_id { '0067h00000Brg8EAAR' }
     term_year { [ '2019 - 20 Spring', '2019 - 20 Fall', '2018 - 19 Fall', '2018 - 19 Spring'].sample }
     book_name { 'Managerial Accounting' }
-    contact_id { '0034C00000Toa9PQAR' }
+    contact_id { '003U000001t59YjIAI' }
     new { false }
     close_date { Date.today - 2 }
     stage_name { 'Confirm Adoption Won' }
@@ -14,9 +14,8 @@ FactoryBot.define do
     number_of_students { Faker::Number.between(from: 1, to: 200) }
     student_number_status { 'Reported' }
     time_period { 'Year' }
-    class_start_date { Date.today }
-    school_id { '0014C00000aB0swQAC' }
-    book_id { 'a0Z4C000002JXWSUA4' }
+    school_id { '001U000001QYuEjIAL' }
+    book_id { 'a0ZU000000IgKrdMAF' }
     lead_source { 'Web' }
   end
 end

--- a/spec/jobs/push_opportunity_to_salesforce_job_spec.rb
+++ b/spec/jobs/push_opportunity_to_salesforce_job_spec.rb
@@ -5,10 +5,12 @@ Sidekiq::Testing.inline!
 RSpec.describe PushOpportunityToSalesforceJob, type: :job, vcr: VCR_OPTS do
   before(:all) do
     @opportunity = FactoryBot.create :api_opportunity
+    @opportunity.stage_name = 'Previous Adoption'
+    @opportunity.save
     @new_opportunity = FactoryBot.create :api_new_opportunity
     # create books for test
-    FactoryBot.create(:api_book, { name: 'Managerial Accounting', salesforce_id: 'a0Z4C000002JXWSUA4' })
-    FactoryBot.create(:api_book, { name: 'Prealgebra', salesforce_id: 'a0Z4C000002JRFOUA4' })
+    FactoryBot.create(:api_book, { name: 'Managerial Accounting', salesforce_id: 'a0ZU000000BGyUSMA1' })
+    FactoryBot.create(:api_book, { name: 'Prealgebra', salesforce_id: 'a0ZU000000DLpEMMA1' })
     VCR.use_cassette('PushOpportunityToSalesforceJob/sf_setup', VCR_OPTS) do
       @proxy = SalesforceProxy.new
       @proxy.setup_cassette


### PR DESCRIPTION
At some point, we may want to move the opportunity update out of a background job. It will depend on how many failures we get since background failures cannot be sent to the frontend.